### PR TITLE
- Clean recording settings requests for each run

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -584,6 +584,8 @@ private:
 
     static void loadRecordingSetting(const Settings& settings_json, RecordingSetting& recording_setting)
     {
+        recording_setting.requests.clear();
+        
         Settings recording_json;
         if (settings_json.getChild("Recording", recording_json)) {
             recording_setting.record_on_move = recording_json.getBool("RecordOnMove", recording_setting.record_on_move);


### PR DESCRIPTION
Fix bug when re-run airsim from UE4 Editor without close the editor.
It caused recording_setting.requests contain the same requests multiple times.