### PR TITLE
Fixed enu coordinate system

### DIFF
--- a/ros2/src/airsim_ros_pkgs/launch/airsim_node.launch.py
+++ b/ros2/src/airsim_ros_pkgs/launch/airsim_node.launch.py
@@ -34,9 +34,6 @@ def generate_launch_description():
             output='screen',
             parameters=[{
                 'is_vulkan': False,
-                'coordinate_system_enu': True,
-                'world_frame_id': "world_enu",
-                'odom_frame_id':  "odom",
                 'update_airsim_img_response_every_n_sec': 0.05,
                 'update_airsim_control_every_n_sec': 0.01,
                 'update_lidar_every_n_sec': 0.01,

--- a/ros2/src/airsim_ros_pkgs/launch/airsim_node.launch.py
+++ b/ros2/src/airsim_ros_pkgs/launch/airsim_node.launch.py
@@ -34,6 +34,9 @@ def generate_launch_description():
             output='screen',
             parameters=[{
                 'is_vulkan': False,
+                'coordinate_system_enu': True,
+                'world_frame_id': "world_enu",
+                'odom_frame_id':  "odom",
                 'update_airsim_img_response_every_n_sec': 0.05,
                 'update_airsim_control_every_n_sec': 0.01,
                 'update_lidar_every_n_sec': 0.01,

--- a/ros2/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros2/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -618,7 +618,6 @@ nav_msgs::msg::Odometry AirsimROSWrapper::get_odom_msg_from_kinematic_state(cons
     odom_msg.twist.twist.angular.z = kinematics_estimated.twist.angular.z();
 
     if (isENU_) {
-        // Seems to work, but why????
         tf2::Quaternion q(
             odom_msg.pose.pose.orientation.w,
             odom_msg.pose.pose.orientation.x,

--- a/ros2/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros2/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -2,8 +2,6 @@
 #include "common/AirSimSettings.hpp"
 #include <tf2_sensor_msgs/tf2_sensor_msgs.h>
 
-#include <math.h>
-
 using namespace std::placeholders;
 
 constexpr char AirsimROSWrapper::CAM_YML_NAME[];
@@ -618,34 +616,29 @@ nav_msgs::msg::Odometry AirsimROSWrapper::get_odom_msg_from_kinematic_state(cons
     odom_msg.twist.twist.angular.x = kinematics_estimated.twist.angular.x();
     odom_msg.twist.twist.angular.y = kinematics_estimated.twist.angular.y();
     odom_msg.twist.twist.angular.z = kinematics_estimated.twist.angular.z();
-    
 
     if (isENU_) {
         // Seems to work, but why????
         tf2::Quaternion q(
-        odom_msg.pose.pose.orientation.w,
-        odom_msg.pose.pose.orientation.x,
-        odom_msg.pose.pose.orientation.y,
-        odom_msg.pose.pose.orientation.z);
+            odom_msg.pose.pose.orientation.w,
+            odom_msg.pose.pose.orientation.x,
+            odom_msg.pose.pose.orientation.y,
+            odom_msg.pose.pose.orientation.z);
         tf2::Matrix3x3 m(q);
         double roll, pitch, yaw;
         m.getRPY(roll, pitch, yaw);
-        // RCLCPP_INFO(nh_->get_logger(), "roll, pitch, yaw - %f, %f, %f", (roll, pitch, yaw));
-        pitch = pitch + M_PI/2;
-        yaw = yaw + M_PI/2;
+        pitch = pitch + M_PI / 2;
+        yaw = yaw + M_PI / 2;
         q.setRPY(roll, pitch, yaw);
-        q.normalize();  
+        q.normalize();
         geometry_msgs::msg::Quaternion quat_msg;
-        // tf2::convert(quat_msg , q);
         quat_msg = tf2::toMsg(q);
-        // RCLCPP_INFO(nh_->get_logger(), "1) roll, pitch, yaw - %f, %f, %f", ( odom_msg.pose.pose.orientation.x,  odom_msg.pose.pose.orientation.y,  odom_msg.pose.pose.orientation.z));
         odom_msg.pose.pose.orientation = quat_msg;
-        // RCLCPP_INFO(nh_->get_logger(), "2) roll, pitch, yaw - %f, %f, %f", ( odom_msg.pose.pose.orientation.x,  odom_msg.pose.pose.orientation.y,  odom_msg.pose.pose.orientation.z));
-        
+
         std::swap(odom_msg.pose.pose.position.x, odom_msg.pose.pose.position.y);
         odom_msg.pose.pose.position.z = -odom_msg.pose.pose.position.z;
         std::swap(odom_msg.pose.pose.orientation.x, odom_msg.pose.pose.orientation.y);
-        odom_msg.pose.pose.orientation.z = -odom_msg.pose.pose.orientation.z ;
+        odom_msg.pose.pose.orientation.z = -odom_msg.pose.pose.orientation.z;
         std::swap(odom_msg.twist.twist.linear.x, odom_msg.twist.twist.linear.y);
         odom_msg.twist.twist.linear.z = -odom_msg.twist.twist.linear.z;
         std::swap(odom_msg.twist.twist.angular.x, odom_msg.twist.twist.angular.y);
@@ -1189,33 +1182,26 @@ void AirsimROSWrapper::set_nans_to_zeros_in_pose(const VehicleSetting& vehicle_s
 void AirsimROSWrapper::convert_tf_msg_to_enu(geometry_msgs::msg::TransformStamped& tf_msg)
 {
     tf2::Quaternion q(
-    tf_msg.transform.rotation.x,
-    tf_msg.transform.rotation.y,
-    tf_msg.transform.rotation.z,
-    tf_msg.transform.rotation.w);
+        tf_msg.transform.rotation.x,
+        tf_msg.transform.rotation.y,
+        tf_msg.transform.rotation.z,
+        tf_msg.transform.rotation.w);
     tf2::Matrix3x3 m(q);
     double roll, pitch, yaw;
     m.getRPY(roll, pitch, yaw);
-    // RCLCPP_INFO(nh_->get_logger(), "roll, pitch, yaw - %f, %f, %f", (roll, pitch, yaw));
-    //pitch = pitch + 1.57;
     roll = roll - M_PI;
-    // yaw = yaw + 1.57;
     q.setRPY(roll, pitch, yaw);
-    q.normalize();  
+    q.normalize();
 
     tf2::Matrix3x3 m2(q);
     m2.getRPY(roll, pitch, yaw);
-    yaw = yaw + M_PI/2;
+    yaw = yaw + M_PI / 2;
     q.setRPY(roll, pitch, yaw);
-    q.normalize();  
+    q.normalize();
 
     geometry_msgs::msg::Quaternion quat_msg;
-    // tf2::convert(quat_msg , q);
     quat_msg = tf2::toMsg(q);
-    // RCLCPP_INFO(nh_->get_logger(), "1) roll, pitch, yaw - %f, %f, %f", ( odom_msg.pose.pose.orientation.x,  odom_msg.pose.pose.orientation.y,  odom_msg.pose.pose.orientation.z));
     tf_msg.transform.rotation = quat_msg;
-    // RCLCPP_INFO(nh_->get_logger(), "2) roll, pitch, yaw - %f, %f, %f", ( odom_msg.pose.pose.orientation.x,  odom_msg.pose.pose.orientation.y,  odom_msg.pose.pose.orientation.z));
-        
 
     std::swap(tf_msg.transform.translation.x, tf_msg.transform.translation.y);
     std::swap(tf_msg.transform.rotation.x, tf_msg.transform.rotation.y);

--- a/ros2/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros2/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -2,6 +2,8 @@
 #include "common/AirSimSettings.hpp"
 #include <tf2_sensor_msgs/tf2_sensor_msgs.h>
 
+#include <math.h>
+
 using namespace std::placeholders;
 
 constexpr char AirsimROSWrapper::CAM_YML_NAME[];
@@ -616,12 +618,34 @@ nav_msgs::msg::Odometry AirsimROSWrapper::get_odom_msg_from_kinematic_state(cons
     odom_msg.twist.twist.angular.x = kinematics_estimated.twist.angular.x();
     odom_msg.twist.twist.angular.y = kinematics_estimated.twist.angular.y();
     odom_msg.twist.twist.angular.z = kinematics_estimated.twist.angular.z();
+    
 
     if (isENU_) {
+        // Seems to work, but why????
+        tf2::Quaternion q(
+        odom_msg.pose.pose.orientation.w,
+        odom_msg.pose.pose.orientation.x,
+        odom_msg.pose.pose.orientation.y,
+        odom_msg.pose.pose.orientation.z);
+        tf2::Matrix3x3 m(q);
+        double roll, pitch, yaw;
+        m.getRPY(roll, pitch, yaw);
+        // RCLCPP_INFO(nh_->get_logger(), "roll, pitch, yaw - %f, %f, %f", (roll, pitch, yaw));
+        pitch = pitch + M_PI/2;
+        yaw = yaw + M_PI/2;
+        q.setRPY(roll, pitch, yaw);
+        q.normalize();  
+        geometry_msgs::msg::Quaternion quat_msg;
+        // tf2::convert(quat_msg , q);
+        quat_msg = tf2::toMsg(q);
+        // RCLCPP_INFO(nh_->get_logger(), "1) roll, pitch, yaw - %f, %f, %f", ( odom_msg.pose.pose.orientation.x,  odom_msg.pose.pose.orientation.y,  odom_msg.pose.pose.orientation.z));
+        odom_msg.pose.pose.orientation = quat_msg;
+        // RCLCPP_INFO(nh_->get_logger(), "2) roll, pitch, yaw - %f, %f, %f", ( odom_msg.pose.pose.orientation.x,  odom_msg.pose.pose.orientation.y,  odom_msg.pose.pose.orientation.z));
+        
         std::swap(odom_msg.pose.pose.position.x, odom_msg.pose.pose.position.y);
         odom_msg.pose.pose.position.z = -odom_msg.pose.pose.position.z;
         std::swap(odom_msg.pose.pose.orientation.x, odom_msg.pose.pose.orientation.y);
-        odom_msg.pose.pose.orientation.z = -odom_msg.pose.pose.orientation.z;
+        odom_msg.pose.pose.orientation.z = -odom_msg.pose.pose.orientation.z ;
         std::swap(odom_msg.twist.twist.linear.x, odom_msg.twist.twist.linear.y);
         odom_msg.twist.twist.linear.z = -odom_msg.twist.twist.linear.z;
         std::swap(odom_msg.twist.twist.angular.x, odom_msg.twist.twist.angular.y);
@@ -1164,6 +1188,35 @@ void AirsimROSWrapper::set_nans_to_zeros_in_pose(const VehicleSetting& vehicle_s
 
 void AirsimROSWrapper::convert_tf_msg_to_enu(geometry_msgs::msg::TransformStamped& tf_msg)
 {
+    tf2::Quaternion q(
+    tf_msg.transform.rotation.x,
+    tf_msg.transform.rotation.y,
+    tf_msg.transform.rotation.z,
+    tf_msg.transform.rotation.w);
+    tf2::Matrix3x3 m(q);
+    double roll, pitch, yaw;
+    m.getRPY(roll, pitch, yaw);
+    // RCLCPP_INFO(nh_->get_logger(), "roll, pitch, yaw - %f, %f, %f", (roll, pitch, yaw));
+    //pitch = pitch + 1.57;
+    roll = roll - M_PI;
+    // yaw = yaw + 1.57;
+    q.setRPY(roll, pitch, yaw);
+    q.normalize();  
+
+    tf2::Matrix3x3 m2(q);
+    m2.getRPY(roll, pitch, yaw);
+    yaw = yaw + M_PI/2;
+    q.setRPY(roll, pitch, yaw);
+    q.normalize();  
+
+    geometry_msgs::msg::Quaternion quat_msg;
+    // tf2::convert(quat_msg , q);
+    quat_msg = tf2::toMsg(q);
+    // RCLCPP_INFO(nh_->get_logger(), "1) roll, pitch, yaw - %f, %f, %f", ( odom_msg.pose.pose.orientation.x,  odom_msg.pose.pose.orientation.y,  odom_msg.pose.pose.orientation.z));
+    tf_msg.transform.rotation = quat_msg;
+    // RCLCPP_INFO(nh_->get_logger(), "2) roll, pitch, yaw - %f, %f, %f", ( odom_msg.pose.pose.orientation.x,  odom_msg.pose.pose.orientation.y,  odom_msg.pose.pose.orientation.z));
+        
+
     std::swap(tf_msg.transform.translation.x, tf_msg.transform.translation.y);
     std::swap(tf_msg.transform.rotation.x, tf_msg.transform.rotation.y);
     tf_msg.transform.translation.z = -tf_msg.transform.translation.z;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
1) Drone base link coordinate system (ENU mode)
2) Drone camera coordinate system (ENU mode)
3) Drone depth camera coordinate system (ENU mode)
<!-- Fixes: # -->

## About
When using ros2 and Airsim simulator, the coordinate system is based on NED. When converting to ENU, each sensor maintain its self coordinate system as NED. This cause a faulty TF between the sensors frames.
<!-- Describe what your PR is about. -->

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

## Screenshots (if appropriate):